### PR TITLE
Add OpenAI plugin examples for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ print(requests.get("http://localhost:8000/v1/resources").json())
 ```
 
 The server output shows a public URL for the Gradio interface so you can try the demo visually.
+
+## LLM/VLM Plugin Example
+
+Plugins can extend the server with new tools. The included `openai_chat` and `openai_vision` plugins show how to call OpenAI models. Set `OPENAI_API_KEY` in your environment and start the server:
+
+```bash
+pip install openai
+python server.py
+```
+
+Invoke the `openai.chat` or `openai.vision` tools via the API or Gradio UI.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,10 @@
+# MCP Tool Plugins
+
+Tools placed in this folder are automatically imported when the server starts. Each module should use the `mcp_tool` decorator to register new tools.
+
+Example plugins included:
+- `openai_chat.py` – text chat completion using OpenAI models
+- `openai_vision.py` – basic image understanding via OpenAI vision models
+
+Set `OPENAI_API_KEY` in your environment for these plugins.
+

--- a/plugins/openai_chat.py
+++ b/plugins/openai_chat.py
@@ -1,0 +1,27 @@
+import os
+from fastapi import HTTPException
+import openai
+from server import mcp_tool, ToolInput
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
+
+@mcp_tool(
+    "openai.chat",
+    "Chat completion via OpenAI API",
+    [
+        ToolInput(name="prompt", type="string", description="User prompt"),
+        ToolInput(name="model", type="string", description="OpenAI model", required=False),
+    ],
+)
+async def openai_chat_tool(params):
+    if not OPENAI_API_KEY:
+        raise HTTPException(500, "OPENAI_API_KEY not configured")
+    model = params.get("model", "gpt-3.5-turbo")
+    resp = await openai.ChatCompletion.acreate(
+        model=model,
+        messages=[{"role": "user", "content": params["prompt"]}],
+    )
+    return {"reply": resp.choices[0].message.content}
+

--- a/plugins/openai_vision.py
+++ b/plugins/openai_vision.py
@@ -1,0 +1,35 @@
+import os
+from fastapi import HTTPException
+import openai
+from server import mcp_tool, ToolInput
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
+
+@mcp_tool(
+    "openai.vision",
+    "Image understanding via OpenAI's vision models",
+    [
+        ToolInput(name="image_url", type="string", description="Public image URL"),
+        ToolInput(name="prompt", type="string", description="Optional prompt", required=False),
+        ToolInput(name="model", type="string", description="OpenAI model", required=False),
+    ],
+)
+async def openai_vision_tool(params):
+    if not OPENAI_API_KEY:
+        raise HTTPException(500, "OPENAI_API_KEY not configured")
+    model = params.get("model", "gpt-4-turbo")
+    user_prompt = params.get("prompt", "Describe the image.")
+    resp = await openai.ChatCompletion.acreate(
+        model=model,
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_prompt},
+                {"type": "image_url", "image_url": {"url": params["image_url"]}},
+            ],
+        }],
+    )
+    return {"reply": resp.choices[0].message.content}
+

--- a/server.py
+++ b/server.py
@@ -8,6 +8,8 @@ import random
 import socket
 import threading
 import uuid
+import importlib
+import pkgutil
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import FastAPI, HTTPException, Request
@@ -121,6 +123,16 @@ def find_free_port(start: int = 7860, end: int = 7960) -> int:
     raise OSError(f"No free port in range {start}-{end}")
 
 
+def load_plugins(path: str = "plugins") -> None:
+    """Dynamically import modules from *path* to register tools."""
+    full = os.path.join(os.path.dirname(__file__), path)
+    if not os.path.isdir(full):
+        return
+    for _, mod, _ in pkgutil.iter_modules([full]):
+        importlib.import_module(f"{path}.{mod}")
+        logger.info("Loaded plugin %s", mod)
+
+
 # ---------------------------------------------------------------------------
 # Mock tools
 # ---------------------------------------------------------------------------
@@ -185,6 +197,9 @@ prompts["hello-world"] = Prompt(
     description="Greets the user",
     template="You are a helpful AI. Greet the user.",
 )
+
+# Load optional tool plugins
+load_plugins()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add plugin folder with OpenAI based `openai_chat` and `openai_vision` tools
- load plugins automatically on server start
- document the plugin system and sample usage in README

## Testing
- `python -m py_compile server.py mcp.py colab_adapter.py plugins/*.py`

------
https://chatgpt.com/codex/tasks/task_b_683fd3beb7c0832d8f5bd980e2621312