### PR TITLE
Add Dockerfile and Cloud Run support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn[standard] gradio==4.* pydantic
+CMD ["python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -56,3 +56,22 @@ python server.py
 ```
 
 Invoke the `openai.chat` or `openai.vision` tools via the API or Gradio UI.
+
+## Deploying to Cloud Run
+
+You can deploy the server on [Google Cloud Run](https://cloud.google.com/run)
+using the provided `Dockerfile`:
+
+```bash
+# build and push the container
+gcloud builds submit --tag gcr.io/PROJECT_ID/mcp-server
+
+# deploy the image to Cloud Run
+gcloud run deploy mcp-server \
+  --image gcr.io/PROJECT_ID/mcp-server \
+  --region REGION \
+  --allow-unauthenticated
+```
+
+Cloud Run sets the `PORT` environment variable automatically, which the server
+uses to expose both the API and Gradio UI on the same endpoint.

--- a/server.py
+++ b/server.py
@@ -327,27 +327,11 @@ Use the tabs to explore resources, invoke tools, or chat via the echo tool."""
             gr.Button("Send").click(echo_chat, [msg, chat], [chat, msg])
 
 
-def run_servers(api_port: int = 8000, ui_port: Optional[int] = None) -> None:
-    """Run FastAPI and Gradio servers concurrently."""
-    if ui_port is None:
-        env_port = int(os.getenv("GRADIO_SERVER_PORT", "7860"))
-        try:
-            ui_port = find_free_port(env_port, env_port)
-        except OSError:
-            ui_port = find_free_port()
-
-    def _run_api():
-        uvicorn.run(app, host="0.0.0.0", port=api_port, log_level="info")
-
-    def _run_ui():
-        demo.launch(server_name="0.0.0.0", server_port=ui_port, show_error=True, share=True)
-
-    t1 = threading.Thread(target=_run_api, daemon=True)
-    t2 = threading.Thread(target=_run_ui, daemon=True)
-    t1.start()
-    t2.start()
-    t1.join()
-    t2.join()
+def run_servers(api_port: int = 8000) -> None:
+    """Run FastAPI with the Gradio UI mounted on the same port."""
+    port = int(os.getenv("PORT", str(api_port)))
+    gr.mount_gradio_app(app, demo, path="/")
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- mount Gradio UI on the same FastAPI port so Cloud Run can expose a single port
- provide Dockerfile for container builds
- document deployment steps to Google Cloud Run

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68413ace0b10832d927aef47705cfc9a