### PR TITLE
Fix plugin loading and include OpenAI dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.10-slim
 WORKDIR /app
 COPY . .
-RUN pip install --no-cache-dir fastapi uvicorn[standard] gradio==4.* pydantic
+RUN pip install --no-cache-dir fastapi uvicorn[standard] gradio==4.* pydantic openai
 CMD ["python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ The server output shows a public URL for the Gradio interface so you can try the
 
 ## LLM/VLM Plugin Example
 
-Plugins can extend the server with new tools. The included `openai_chat` and `openai_vision` plugins show how to call OpenAI models. Set `OPENAI_API_KEY` in your environment and start the server:
+Plugins can extend the server with new tools. The included `openai_chat` and `openai_vision` plugins show how to call OpenAI models. Set `OPENAI_API_KEY` in your environment and start the server.
+
+If running locally, install the `openai` package first:
 
 ```bash
 pip install openai
 python server.py
 ```
 
-Invoke the `openai.chat` or `openai.vision` tools via the API or Gradio UI.
+The Dockerfile installs `openai` automatically. Invoke the `openai.chat` or `openai.vision` tools via the API or Gradio UI.
 
 ## Deploying to Cloud Run
 

--- a/server.py
+++ b/server.py
@@ -129,8 +129,13 @@ def load_plugins(path: str = "plugins") -> None:
     if not os.path.isdir(full):
         return
     for _, mod, _ in pkgutil.iter_modules([full]):
-        importlib.import_module(f"{path}.{mod}")
-        logger.info("Loaded plugin %s", mod)
+        try:
+            importlib.import_module(f"{path}.{mod}")
+            logger.info("Loaded plugin %s", mod)
+        except ModuleNotFoundError as e:
+            logger.warning("Skipping plugin %s: %s", mod, e)
+        except Exception as e:
+            logger.exception("Failed to load plugin %s: %s", mod, e)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- install the `openai` package in the Docker image
- handle missing plugin dependencies gracefully
- clarify plugin instructions in README

## Testing
- `ruff check server.py` *(fails: F401, E731)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684182b2b688832da228b6e032850eae