### PR TITLE
Fix JSONResponse usage in error handler

### DIFF
--- a/server.py
+++ b/server.py
@@ -223,7 +223,7 @@ app.add_middleware(
 @app.exception_handler(Exception)
 async def universal_error(request: Request, exc: Exception):
     logger.exception("Unhandled exception: %s", exc)
-    return JSONResponse(500, {"error": str(exc)})
+    return JSONResponse(status_code=500, content={"error": str(exc)})
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- fix incorrect argument order in `universal_error` handler

## Testing
- `python -m py_compile server.py plugins/openai_chat.py plugins/openai_vision.py mcp.py colab_adapter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6841d3d63f24832d91a8f4551ac3497e