### PR TITLE
Replace Gradio UI with static HTML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.10-slim
 WORKDIR /app
 COPY . .
-RUN pip install --no-cache-dir fastapi uvicorn[standard] gradio==4.* pydantic openai
+RUN pip install --no-cache-dir fastapi uvicorn[standard] pydantic openai
 CMD ["python", "server.py"]

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>MCP Demo UI</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>MCP Demo UI</h1>
+<nav>
+  <button id="tab-resources">Resources</button>
+  <button id="tab-tools">Tools</button>
+  <button id="tab-chat">Chat</button>
+</nav>
+<section id="resources" class="tab">
+  <button id="refresh-resources">Refresh</button>
+  <table id="resources-table">
+    <thead><tr><th>URI</th><th>Description</th></tr></thead>
+    <tbody></tbody>
+  </table>
+</section>
+<section id="tools" class="tab hidden">
+  <label>Tool:
+    <select id="tool-select"></select>
+  </label>
+  <label>Params:
+    <textarea id="tool-params">{}</textarea>
+  </label>
+  <button id="run-tool">Run</button>
+  <pre id="tool-output"></pre>
+</section>
+<section id="chat" class="tab hidden">
+  <div id="chat-window"></div>
+  <input type="text" id="chat-input" placeholder="Type a message">
+  <button id="send-chat">Send</button>
+</section>
+<script src="script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,80 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const sections = {
+    'tab-resources': document.getElementById('resources'),
+    'tab-tools': document.getElementById('tools'),
+    'tab-chat': document.getElementById('chat')
+  };
+
+  Object.keys(sections).forEach(btnId => {
+    document.getElementById(btnId).addEventListener('click', () => {
+      Object.values(sections).forEach(sec => sec.classList.add('hidden'));
+      sections[btnId].classList.remove('hidden');
+    });
+  });
+
+  async function loadResources() {
+    const resp = await fetch('/v1/resources');
+    const data = await resp.json();
+    const tbody = document.querySelector('#resources-table tbody');
+    tbody.innerHTML = '';
+    data.forEach(r => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${r.uri}</td><td>${r.description}</td>`;
+      tbody.appendChild(row);
+    });
+  }
+
+  document.getElementById('refresh-resources').addEventListener('click', loadResources);
+  loadResources();
+
+  let tools = {};
+  let echoId = null;
+  async function loadTools() {
+    const resp = await fetch('/v1/tool');
+    const data = await resp.json();
+    const select = document.getElementById('tool-select');
+    select.innerHTML = '';
+    data.forEach(item => {
+      const id = Object.keys(item)[0];
+      const t = item[id];
+      tools[id] = t;
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = t.name;
+      select.appendChild(opt);
+      if (t.name === 'echo' && !echoId) echoId = id;
+    });
+  }
+
+  document.getElementById('run-tool').addEventListener('click', async () => {
+    const toolId = document.getElementById('tool-select').value;
+    let params = {};
+    try { params = JSON.parse(document.getElementById('tool-params').value); } catch (e) {}
+    const resp = await fetch(`/v1/tool/${toolId}/invoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 1, method: 'invoke', params })
+    });
+    const data = await resp.json();
+    document.getElementById('tool-output').textContent = JSON.stringify(data, null, 2);
+  });
+
+  document.getElementById('send-chat').addEventListener('click', async () => {
+    const input = document.getElementById('chat-input');
+    if (!echoId || !input.value) return;
+    const msg = input.value;
+    input.value = '';
+    const resp = await fetch(`/v1/tool/${echoId}/invoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 1, method: 'invoke', params: { text: msg } })
+    });
+    const data = await resp.json();
+    const div = document.getElementById('chat-window');
+    div.innerHTML += `<div><strong>You:</strong> ${msg}</div>`;
+    div.innerHTML += `<div><strong>Bot:</strong> ${JSON.stringify(data.result)}</div>`;
+    div.scrollTop = div.scrollHeight;
+  });
+
+  loadTools();
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+nav button { margin-right: 10px; }
+.hidden { display: none; }
+#chat-window { border: 1px solid #ccc; height: 200px; overflow-y: auto; margin-bottom: 10px; padding: 5px; }


### PR DESCRIPTION
## Summary
- drop gradio dependency
- serve static HTML/JS UI from `static` folder
- adjust `run_servers` accordingly
- update Dockerfile

## Testing
- `ruff check server.py`
- `python -m py_compile server.py`
- `ruff check .` *(fails: multiple existing lint errors)*
- `pip install fastapi uvicorn[standard] pydantic`
- `python server.py &` and `curl http://localhost:8000/health`


------
https://chatgpt.com/codex/tasks/task_b_684306cf3008832d8a6dcb0e8f54af47