### PR TITLE
Add navigate endpoint and analyzer

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,6 +19,10 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 import uvicorn
 try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+try:
     from sse_starlette.sse import EventSourceResponse  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     EventSourceResponse = None
@@ -145,6 +149,40 @@ def load_plugins(path: str = "plugins") -> None:
             logger.exception("Failed to load plugin %s: %s", mod, e)
 
 
+async def analyze_chat_for_actions(chat_history: str) -> Dict[str, Any]:
+    """Parse chat history and suggest next actions.
+
+    Uses OpenAI if configured, otherwise falls back to naive heuristics.
+    """
+    if openai and os.getenv("OPENAI_API_KEY"):
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        system_prompt = (
+            "Analyze the following chat history and return a JSON object describing "
+            "any actions the system should take. Include fields to gather from the "
+            "user and the next recommended step."
+        )
+        try:
+            resp = await openai.ChatCompletion.acreate(
+                model=os.getenv("ANALYSIS_MODEL", "gpt-3.5-turbo"),
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": chat_history},
+                ],
+                temperature=0,
+            )
+            return json.loads(resp.choices[0].message.content)
+        except Exception as e:  # pragma: no cover - network failures
+            logger.exception("LLM analysis failed: %s", e)
+
+    # Fallback heuristic
+    text = chat_history.lower()
+    if "weather" in text:
+        return {"actions": [{"tool": "weather.fake", "fields": ["location"]}]}
+    if any(k in text for k in ["calc", "calculate", "+", "-"]):
+        return {"actions": [{"tool": "calculator", "fields": ["expression"]}]}
+    return {"actions": []}
+
+
 # ---------------------------------------------------------------------------
 # Mock tools
 # ---------------------------------------------------------------------------
@@ -255,6 +293,16 @@ async def list_tools():
 @app.get("/v1/prompts")
 async def list_prompts():
     return [p.dict() for p in prompts.values()]
+
+
+class NavigateReq(BaseModel):
+    chat_history: str
+
+
+@app.post("/api/navigate")
+async def navigate(req: NavigateReq):
+    """Analyze chat history and return suggested actions."""
+    return await analyze_chat_for_actions(req.chat_history)
 
 
 class InitReq(BaseModel):

--- a/tests/test_navigate.py
+++ b/tests/test_navigate.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from server import app
+
+client = TestClient(app)
+
+def test_navigate_weather():
+    resp = client.post('/api/navigate', json={'chat_history': 'What is the weather today?'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    assert 'actions' in data
+    # ensure at least one action predicted for weather
+    assert any(act.get('tool') == 'weather.fake' for act in data.get('actions', []))
+


### PR DESCRIPTION
## Summary
- add navigation API endpoint and chat analyzer
- implement fallback heuristics when OpenAI isn't configured
- test navigation API

## Testing
- `ruff check server.py tests/test_navigate.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68525449470c832d88f7c9dd03fc4413