### PR TITLE
Add secure user data store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.10-slim
 WORKDIR /app
 COPY . .
-RUN pip install --no-cache-dir fastapi uvicorn[standard] pydantic openai sse-starlette
+RUN pip install --no-cache-dir fastapi uvicorn[standard] pydantic openai sse-starlette cryptography
 CMD ["python", "server.py"]

--- a/secure_store.py
+++ b/secure_store.py
@@ -1,0 +1,61 @@
+import os
+import sqlite3
+import base64
+from typing import Optional
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
+from cryptography.fernet import Fernet
+
+_DB_PATH = os.getenv("USERDATA_DB", "userdata.db")
+_MASTER_KEY = os.getenv("MASTER_KEY")
+
+
+def _get_master_key() -> bytes:
+    if not _MASTER_KEY:
+        raise RuntimeError("MASTER_KEY environment variable not set")
+    return _MASTER_KEY.encode()
+
+
+def _get_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(_DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS userdata (user_id TEXT PRIMARY KEY, value BLOB NOT NULL)"
+    )
+    return conn
+
+
+def _derive_key(user_id: str) -> bytes:
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=user_id.encode(),
+        iterations=390000,
+    )
+    key = base64.urlsafe_b64encode(kdf.derive(_get_master_key()))
+    return key
+
+
+def store_user_data(user_id: str, value: str) -> None:
+    """Encrypt and store *value* for *user_id*."""
+    f = Fernet(_derive_key(user_id))
+    token = f.encrypt(value.encode())
+    conn = _get_db()
+    with conn:
+        conn.execute(
+            "REPLACE INTO userdata (user_id, value) VALUES (?, ?)", (user_id, token)
+        )
+    conn.close()
+
+
+def retrieve_user_data(user_id: str) -> Optional[str]:
+    """Return decrypted value for *user_id* or ``None`` if not found."""
+    conn = _get_db()
+    row = conn.execute(
+        "SELECT value FROM userdata WHERE user_id=?", (user_id,)
+    ).fetchone()
+    conn.close()
+    if not row:
+        return None
+    token = row[0]
+    f = Fernet(_derive_key(user_id))
+    return f.decrypt(token).decode()

--- a/tests/test_secure_store.py
+++ b/tests/test_secure_store.py
@@ -1,0 +1,23 @@
+import importlib
+import sqlite3
+import pathlib
+import sys
+
+
+def test_store_and_retrieve(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("USERDATA_DB", str(db_path))
+    monkeypatch.setenv("MASTER_KEY", "secret_master")
+
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    import secure_store
+    secure_store = importlib.reload(secure_store)
+
+    secure_store.store_user_data("alice", "wonderland")
+    assert secure_store.retrieve_user_data("alice") == "wonderland"
+
+    # raw stored value should not match plaintext
+    conn = sqlite3.connect(db_path)
+    token = conn.execute("SELECT value FROM userdata WHERE user_id=?", ("alice",)).fetchone()[0]
+    conn.close()
+    assert b"wonderland" not in token


### PR DESCRIPTION
## Summary
- add `secure_store.py` with Fernet-based encryption, deriving per-user keys from `MASTER_KEY`
- persist encrypted values into SQLite (`userdata.db`)
- install `cryptography` in Docker image
- include basic unit test verifying encryption and retrieval

## Testing
- `flake8 secure_store.py tests/test_secure_store.py`
- `pytest -q tests/test_secure_store.py`


------
https://chatgpt.com/codex/tasks/task_b_685254495684832da5ee5b7831afc49a