### PR TITLE
Implement user data API with token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,32 @@ connection open to stream updates.
 Configure your ChatGPT connector to point at your server’s base URL and use the
 `/mcp` endpoint for both non‑streaming and streaming interactions.
 
+## User Data API
+
+Authenticated sessions can store and manage user‑specific JSON payloads.
+First request a session ID then pass it as a bearer token:
+
+```bash
+# create a session and grab the token
+TOKEN=$(curl -s -X POST http://localhost:8000/v1/initialize \
+  -H 'Content-Type: application/json' \
+  -d '{"id":1,"jsonrpc":"2.0","method":"initialize","params":{}}' \
+  | jq -r '.result.sessionId')
+
+# store data
+curl -X POST http://localhost:8000/api/user/data \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"foo":"bar"}'
+
+# fetch it back
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/user/data
+
+# remove it
+curl -X DELETE -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/user/data
+```
+
 ## Deploying to Cloud Run
 
 You can deploy the server on [Google Cloud Run](https://cloud.google.com/run)

--- a/secure_store.py
+++ b/secure_store.py
@@ -1,0 +1,33 @@
+import json
+import os
+from typing import Any, Optional
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "user_store")
+os.makedirs(DATA_DIR, exist_ok=True)
+
+
+def _path(user_id: str) -> str:
+    return os.path.join(DATA_DIR, f"{user_id}.json")
+
+
+def load_user_data(user_id: str) -> Optional[Any]:
+    """Return stored data for *user_id* or ``None`` if not found."""
+    path = _path(user_id)
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_user_data(user_id: str, data: Any) -> None:
+    """Persist ``data`` for *user_id*."""
+    with open(_path(user_id), "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+def delete_user_data(user_id: str) -> None:
+    """Delete stored data for *user_id*."""
+    try:
+        os.remove(_path(user_id))
+    except FileNotFoundError:
+        pass

--- a/tests/test_user_data.py
+++ b/tests/test_user_data.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from fastapi.testclient import TestClient
+
+from server import app
+from secure_store import load_user_data, DATA_DIR
+
+client = TestClient(app)
+
+
+def create_token():
+    resp = client.post(
+        "/v1/initialize",
+        json={"id": 1, "jsonrpc": "2.0", "params": {}, "method": "initialize"},
+    )
+    return resp.json()["result"]["sessionId"]
+
+
+def test_requires_auth():
+    r = client.get("/api/user/data")
+    assert r.status_code == 401
+
+
+def setup_module(module):
+    if os.path.isdir(DATA_DIR):
+        shutil.rmtree(DATA_DIR)
+    os.makedirs(DATA_DIR, exist_ok=True)
+
+
+def test_post_get_delete_cycle():
+    token = create_token()
+    payload = {"foo": "bar"}
+    headers = {"Authorization": f"Bearer {token}"}
+
+    r = client.post("/api/user/data", json=payload, headers=headers)
+    assert r.status_code == 200
+
+    r = client.get("/api/user/data", headers=headers)
+    assert r.json() == payload
+
+    # other session should not see data
+    other_token = create_token()
+    r = client.get("/api/user/data", headers={"Authorization": f"Bearer {other_token}"})
+    assert r.json() == {}
+
+    r = client.delete("/api/user/data", headers=headers)
+    assert r.status_code == 200
+    assert load_user_data(token) is None
+


### PR DESCRIPTION
## Summary
- add a simple `secure_store` helper for per-session data
- support `/api/user/data` with GET, POST and DELETE
- document the new endpoint with curl examples
- test authentication and data isolation

## Testing
- `ruff check server.py secure_store.py tests/test_user_data.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6852544ab69c832d9f4ded1b4b7bce6b