### PR TITLE
Add o4-mini demo documentation and tools

### DIFF
--- a/docs/o4mini_example.md
+++ b/docs/o4mini_example.md
@@ -1,0 +1,145 @@
+# o4-mini Integration Example
+
+This document demonstrates how to connect the hypothetical `o4-mini` language model
+to the MCP server using a custom tool. We also create a sample tool that
+provides synthetic company data and a minimal web page to interact with the
+model.
+
+## 1. Integration steps
+
+1. **Create a plugin for the `o4-mini` model.**
+   The plugin defines a new MCP tool that sends a request to the model's API
+   endpoint and returns the generated text.
+2. **Create a sample company database tool.**
+   This tool exposes a small in-memory dataset that the model can query.
+3. **Expose the tools via the existing MCP server.**
+   When the server starts it automatically loads modules from the `plugins`
+   directory, registering any tools defined with the `mcp_tool` decorator.
+4. **Build a simple web page.**
+   The page lets you enter a prompt, calls the `o4-mini` tool and displays the
+   response.
+5. **Run the server and open the page in your browser.**
+
+## 2. Code snippets
+
+### a. Connecting to the `o4-mini` model
+
+```python
+# plugins/o4mini_chat.py
+import os
+from fastapi import HTTPException
+import httpx
+from server import mcp_tool, ToolInput
+
+# Endpoint of the o4-mini API
+O4MINI_ENDPOINT = os.getenv("O4MINI_ENDPOINT", "http://localhost:4900/generate")
+
+@mcp_tool(
+    "o4mini.chat",
+    "Chat completion using the o4-mini model",
+    [ToolInput(name="prompt", type="string", description="User prompt")],
+)
+async def o4mini_chat_tool(params):
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(O4MINI_ENDPOINT, json={"prompt": params["prompt"]})
+    if resp.status_code != 200:
+        raise HTTPException(500, f"Model error: {resp.text}")
+    data = resp.json()
+    return {"reply": data.get("response", "")}
+```
+
+### b. Sample company database tool
+
+```python
+# plugins/company_db.py
+from server import mcp_tool, ToolInput
+
+COMPANIES = [
+    {"id": 1, "name": "Acme Corp", "industry": "Manufacturing", "employees": 250},
+    {"id": 2, "name": "Globex Inc", "industry": "Technology", "employees": 500},
+    {"id": 3, "name": "Soylent Corp", "industry": "Food", "employees": 300},
+]
+
+@mcp_tool(
+    "company.search",
+    "Search the sample company database",
+    [ToolInput(name="query", type="string", description="Name or industry")],
+)
+async def company_search_tool(params):
+    term = params["query"].lower()
+    matches = [c for c in COMPANIES if term in c["name"].lower() or term in c["industry"].lower()]
+    return {"results": matches}
+```
+
+### c. Minimal web page
+
+```html
+<!-- static/o4mini_demo.html -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>o4-mini Demo</title>
+</head>
+<body>
+  <h2>Ask the o4-mini model</h2>
+  <input type="text" id="prompt" placeholder="Enter prompt" />
+  <button id="send">Send</button>
+  <pre id="reply"></pre>
+
+  <script>
+  document.getElementById('send').addEventListener('click', async () => {
+      const prompt = document.getElementById('prompt').value;
+      const resp = await fetch('/v1/tool/' + window.o4miniId + '/invoke', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({id: 1, method: 'invoke', params: {prompt}})
+      });
+      const data = await resp.json();
+      document.getElementById('reply').textContent = data.result.reply;
+  });
+
+  // fetch tool list on load to discover the o4-mini tool ID
+  fetch('/v1/tool').then(r => r.json()).then(list => {
+      for (const item of list) {
+          const id = Object.keys(item)[0];
+          if (item[id].name === 'o4mini.chat') {
+              window.o4miniId = id;
+              break;
+          }
+      }
+  });
+  </script>
+</body>
+</html>
+```
+
+## 3. Sample prompts and outputs
+
+Example prompt:
+
+```
+List companies in the technology industry.
+```
+
+Expected model workflow:
+1. The `o4-mini` model receives the prompt.
+2. It may call the `company.search` tool with the query `technology`.
+3. The tool returns the matching record for `Globex Inc`.
+4. The model replies with a description of that company.
+
+## 4. Running the demo
+
+1. Install dependencies and start the server:
+
+```bash
+pip install fastapi uvicorn httpx
+python server.py
+```
+
+2. Open `http://localhost:8000/o4mini_demo.html` in your browser.
+3. Enter a prompt such as *"Tell me about companies in manufacturing"*.
+4. The reply from the `o4-mini` model will appear below the button.
+
+This setup shows how new tools can be combined with a model via the MCP server
+and exposed through a simple webpage.

--- a/plugins/company_db.py
+++ b/plugins/company_db.py
@@ -1,0 +1,17 @@
+from server import mcp_tool, ToolInput
+
+COMPANIES = [
+    {"id": 1, "name": "Acme Corp", "industry": "Manufacturing", "employees": 250},
+    {"id": 2, "name": "Globex Inc", "industry": "Technology", "employees": 500},
+    {"id": 3, "name": "Soylent Corp", "industry": "Food", "employees": 300},
+]
+
+@mcp_tool(
+    "company.search",
+    "Search the sample company database",
+    [ToolInput(name="query", type="string", description="Name or industry")],
+)
+async def company_search_tool(params):
+    term = params["query"].lower()
+    matches = [c for c in COMPANIES if term in c["name"].lower() or term in c["industry"].lower()]
+    return {"results": matches}

--- a/plugins/o4mini_chat.py
+++ b/plugins/o4mini_chat.py
@@ -1,0 +1,19 @@
+import os
+from fastapi import HTTPException
+import httpx
+from server import mcp_tool, ToolInput
+
+O4MINI_ENDPOINT = os.getenv("O4MINI_ENDPOINT", "http://localhost:4900/generate")
+
+@mcp_tool(
+    "o4mini.chat",
+    "Chat completion using the o4-mini model",
+    [ToolInput(name="prompt", type="string", description="User prompt")],
+)
+async def o4mini_chat_tool(params):
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(O4MINI_ENDPOINT, json={"prompt": params["prompt"]})
+    if resp.status_code != 200:
+        raise HTTPException(500, f"Model error: {resp.text}")
+    data = resp.json()
+    return {"reply": data.get("response", "")}

--- a/secure_store.py
+++ b/secure_store.py
@@ -1,33 +1,85 @@
-import json
 import os
+import sqlite3
+import base64
+import hashlib
 from typing import Any, Optional
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "user_store")
 os.makedirs(DATA_DIR, exist_ok=True)
 
 
-def _path(user_id: str) -> str:
-    return os.path.join(DATA_DIR, f"{user_id}.json")
+def _get_db_path() -> str:
+    return os.getenv("USERDATA_DB", os.path.join(DATA_DIR, "data.db"))
 
 
-def load_user_data(user_id: str) -> Optional[Any]:
+def _get_db_conn() -> sqlite3.Connection:
+    path = _get_db_path()
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS userdata (user_id TEXT PRIMARY KEY, value BLOB)"
+    )
+    return conn
+
+
+def _master_key() -> bytes:
+    key = os.getenv("MASTER_KEY", "default_secret").encode("utf-8")
+    return hashlib.sha256(key).digest()
+
+
+def _xor(data: bytes, key: bytes) -> bytes:
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+
+
+def _encrypt(text: str) -> bytes:
+    return base64.b64encode(_xor(text.encode("utf-8"), _master_key()))
+
+
+def _decrypt(token: bytes) -> str:
+    return _xor(base64.b64decode(token), _master_key()).decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def store_user_data(user_id: str, data: Any) -> None:
+    """Store ``data`` for *user_id* in the database."""
+    conn = _get_db_conn()
+    import json
+    enc = _encrypt(json.dumps(data))
+    conn.execute(
+        "REPLACE INTO userdata (user_id, value) VALUES (?, ?)",
+        (user_id, enc),
+    )
+    conn.commit()
+    conn.close()
+
+
+def retrieve_user_data(user_id: str) -> Optional[str]:
     """Return stored data for *user_id* or ``None`` if not found."""
-    path = _path(user_id)
-    if not os.path.exists(path):
+    conn = _get_db_conn()
+    row = conn.execute(
+        "SELECT value FROM userdata WHERE user_id=?", (user_id,)
+    ).fetchone()
+    conn.close()
+    if row is None:
         return None
-    with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)
+    import json
+    return json.loads(_decrypt(row[0]))
+
+
+# Backwards compat for earlier file-based API ---------------------------------
+
+def load_user_data(user_id: str) -> Optional[str]:
+    return retrieve_user_data(user_id)
 
 
 def save_user_data(user_id: str, data: Any) -> None:
-    """Persist ``data`` for *user_id*."""
-    with open(_path(user_id), "w", encoding="utf-8") as fh:
-        json.dump(data, fh)
+    store_user_data(user_id, data)
 
 
 def delete_user_data(user_id: str) -> None:
-    """Delete stored data for *user_id*."""
-    try:
-        os.remove(_path(user_id))
-    except FileNotFoundError:
-        pass
+    conn = _get_db_conn()
+    conn.execute("DELETE FROM userdata WHERE user_id=?", (user_id,))
+    conn.commit()
+    conn.close()

--- a/static/o4mini_demo.html
+++ b/static/o4mini_demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>o4-mini Demo</title>
+</head>
+<body>
+  <h2>Ask the o4-mini model</h2>
+  <input type="text" id="prompt" placeholder="Enter prompt" />
+  <button id="send">Send</button>
+  <pre id="reply"></pre>
+
+  <script>
+  document.getElementById('send').addEventListener('click', async () => {
+      const prompt = document.getElementById('prompt').value;
+      const resp = await fetch('/v1/tool/' + window.o4miniId + '/invoke', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({id: 1, method: 'invoke', params: {prompt}})
+      });
+      const data = await resp.json();
+      document.getElementById('reply').textContent = data.result.reply;
+  });
+
+  fetch('/v1/tool').then(r => r.json()).then(list => {
+      for (const item of list) {
+          const id = Object.keys(item)[0];
+          if (item[id].name === 'o4mini.chat') {
+              window.o4miniId = id;
+              break;
+          }
+      }
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add secure_store database implementation
- add new plugins for o4-mini chat and company data
- provide demo HTML page and documentation for using o4-mini

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685da8b50f88832dabd261f94c5aa55f