### PR TITLE
Add usage examples page

### DIFF
--- a/secure_store.py
+++ b/secure_store.py
@@ -1,6 +1,11 @@
+import base64
+import hashlib
 import json
 import os
+import sqlite3
 from typing import Any, Optional
+
+from cryptography.fernet import Fernet
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "user_store")
 os.makedirs(DATA_DIR, exist_ok=True)
@@ -25,9 +30,46 @@ def save_user_data(user_id: str, data: Any) -> None:
         json.dump(data, fh)
 
 
+def store_user_data(user_id: str, data: Any) -> None:
+    """Persist encrypted ``data`` for *user_id* using SQLite."""
+    db = os.getenv("USERDATA_DB", os.path.join(os.path.dirname(__file__), "user_data.db"))
+    key = os.getenv("MASTER_KEY", "default").encode()
+    fernet = Fernet(base64.urlsafe_b64encode(hashlib.sha256(key).digest()))
+    enc = fernet.encrypt(data.encode() if isinstance(data, str) else json.dumps(data).encode())
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS userdata (user_id TEXT PRIMARY KEY, value BLOB)"
+    )
+    conn.execute(
+        "REPLACE INTO userdata (user_id, value) VALUES (?, ?)",
+        (user_id, enc),
+    )
+    conn.commit()
+    conn.close()
+
+
 def delete_user_data(user_id: str) -> None:
     """Delete stored data for *user_id*."""
     try:
         os.remove(_path(user_id))
     except FileNotFoundError:
         pass
+
+
+def retrieve_user_data(user_id: str) -> Optional[Any]:
+    """Return decrypted data for *user_id* stored via :func:`store_user_data`."""
+    db = os.getenv("USERDATA_DB", os.path.join(os.path.dirname(__file__), "user_data.db"))
+    if not os.path.exists(db):
+        return None
+    key = os.getenv("MASTER_KEY", "default").encode()
+    fernet = Fernet(base64.urlsafe_b64encode(hashlib.sha256(key).digest()))
+    conn = sqlite3.connect(db)
+    row = conn.execute("SELECT value FROM userdata WHERE user_id=?", (user_id,)).fetchone()
+    conn.close()
+    if not row:
+        return None
+    val = fernet.decrypt(row[0])
+    try:
+        return json.loads(val)
+    except Exception:
+        return val.decode()

--- a/static/examples.html
+++ b/static/examples.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Usage Examples</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Usage Examples</h1>
+<button id="btn-resources">List Resources</button>
+<button id="btn-echo">Echo Hello</button>
+<button id="btn-weather">Random Weather</button>
+<pre id="output"></pre>
+<script>
+async function getToolId(name) {
+  const resp = await fetch('/v1/tool');
+  const data = await resp.json();
+  for (const item of data) {
+    const id = Object.keys(item)[0];
+    if (item[id].name === name) {
+      return id;
+    }
+  }
+  return null;
+}
+
+document.getElementById('btn-resources').addEventListener('click', async () => {
+  const resp = await fetch('/v1/resources');
+  document.getElementById('output').textContent = JSON.stringify(await resp.json(), null, 2);
+});
+
+document.getElementById('btn-echo').addEventListener('click', async () => {
+  const id = await getToolId('echo');
+  if (!id) return;
+  const resp = await fetch(`/v1/tool/${id}/invoke`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: 1, method: 'invoke', params: { text: 'Hello' } })
+  });
+  document.getElementById('output').textContent = JSON.stringify(await resp.json(), null, 2);
+});
+
+document.getElementById('btn-weather').addEventListener('click', async () => {
+  const id = await getToolId('weather.fake');
+  if (!id) return;
+  const resp = await fetch(`/v1/tool/${id}/invoke`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: 1, method: 'invoke', params: { location: 'Boston' } })
+  });
+  document.getElementById('output').textContent = JSON.stringify(await resp.json(), null, 2);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `examples.html` with interactive buttons for demo actions
- expand `secure_store` with sqlite-backed encrypted functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685da949e8f0832d9eb659a40f8f9d55