### PR TITLE
Implement snippet embed API and tools

### DIFF
--- a/plugins/snippet_db.py
+++ b/plugins/snippet_db.py
@@ -1,0 +1,67 @@
+from server import mcp_tool, ToolInput
+import sqlite3
+import os
+
+DEFAULT_DB = "snippets.sqlite3"
+
+
+def _get_conn() -> sqlite3.Connection:
+    """Return a connection to the snippets DB ensuring the table exists."""
+    path = os.getenv("SNIPPET_DB", DEFAULT_DB)
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS snippets (
+            id TEXT PRIMARY KEY,
+            html TEXT,
+            plain TEXT,
+            markdown TEXT,
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )"""
+    )
+    return conn
+
+
+@mcp_tool(
+    "snippet.search",
+    "Search saved chat snippets",
+    [ToolInput(name="query", type="string", description="keywords")],
+)
+async def snippet_search(params):
+    q = f"%{params['query']}%"
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT id, substr(plain,1,160) FROM snippets "
+        "WHERE plain LIKE ? ORDER BY created DESC LIMIT 10",
+        (q,),
+    )
+    results = [
+        {"id": r[0], "title": f"Snippet {r[0]}", "text": r[1], "url": f"/s/{r[0]}"}
+        for r in cur
+    ]
+    conn.close()
+    return {"results": results}
+
+
+@mcp_tool(
+    "snippet.fetch",
+    "Fetch full saved snippet by id",
+    [ToolInput(name="id", type="string", description="snippet id")],
+)
+async def snippet_fetch(params):
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT id, html, plain, markdown FROM snippets WHERE id=?",
+        (params["id"],),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        return {}
+    return {
+        "id": row[0],
+        "title": f"Snippet {row[0]}",
+        "html": row[1],
+        "text": row[2],
+        "markdown": row[3],
+        "url": f"/s/{row[0]}",
+    }

--- a/tests/test_snippet_embed.py
+++ b/tests/test_snippet_embed.py
@@ -1,0 +1,47 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+# configure separate db for test
+DB_PATH = os.path.join(os.path.dirname(__file__), 'snippets_test.db')
+if os.path.exists(DB_PATH):
+    os.unlink(DB_PATH)
+os.environ['SNIPPET_DB'] = DB_PATH
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from server import app
+
+client = TestClient(app)
+
+
+def _tool_id(name: str) -> str:
+    tools = client.get('/v1/tool').json()
+    for item in tools:
+        tid, info = next(iter(item.items()))
+        if info['name'] == name:
+            return tid
+    raise AssertionError(f'tool {name} not found')
+
+
+
+
+
+def test_embed_and_tools():
+    resp = client.post('/api/embed', json={'html': '<b>Hi</b>', 'plain': 'Hi', 'sources': []})
+    assert resp.status_code == 200
+    data = resp.json()
+    snip_id = data['id']
+    assert data['sanitizedHtml']
+
+    fetch_id = _tool_id('snippet.fetch')
+    search_id = _tool_id('snippet.search')
+
+    r = client.post(f'/v1/tool/{fetch_id}/invoke', json={'id': 1, 'jsonrpc': '2.0', 'method': 'fetch', 'params': {'id': snip_id}})
+    assert r.status_code == 200
+    fetched = r.json()['result']
+    assert fetched['text'] == 'Hi'
+
+    r = client.post(f'/v1/tool/{search_id}/invoke', json={'id': 1, 'jsonrpc': '2.0', 'method': 'search', 'params': {'query': 'Hi'}})
+    assert r.status_code == 200
+    results = r.json()['result']['results']
+    assert any(s['id'] == snip_id for s in results)


### PR DESCRIPTION
## Summary
- add snippet embed API to save sanitized snippets
- implement `snippet.search` and `snippet.fetch` MCP tools
- test snippet embedding via FastAPI and MCP

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e4a55aab8832da1901c3f612fd36c