### PR TITLE
Add OPENAI_API_KEY sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Run the server locally:
 python server.py
 ```
 
+Create a `dev.env` file and add your OpenAI API key:
+
+```bash
+OPENAI_API_KEY=your-openai-key
+```
+
 Inside Google Colab or other notebooks use the helper:
 
 ```python

--- a/dev.env
+++ b/dev.env
@@ -1,1 +1,2 @@
 ELEVENLABS_MCP_SECRET=super-long-random-string
+OPENAI_API_KEY=your-openai-key


### PR DESCRIPTION
## Summary
- set `OPENAI_API_KEY` in `dev.env`
- document `OPENAI_API_KEY` usage when running locally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870a5de58e8832da420b99331d0c260