### PR TITLE
Handle ElevenLabs audio files

### DIFF
--- a/plugins/audio_transcriber.py
+++ b/plugins/audio_transcriber.py
@@ -1,14 +1,34 @@
 import os
-from pathlib import Path
 import tempfile
+from pathlib import Path
+
 import httpx
 from fastapi import HTTPException
+
 try:
     import openai
 except Exception:  # pragma: no cover - optional dependency
     openai = None
 
-from server import mcp_tool, ToolInput
+from server import ToolInput, mcp_tool
+
+
+def _guess_extension(content_type: str) -> str:
+    """Return file extension for HTTP *content_type*."""
+    ct = content_type.split(";", 1)[0].lower()
+    mapping = {
+        "audio/mpeg": ".mp3",
+        "audio/mp3": ".mp3",
+        "audio/x-mpeg": ".mp3",
+        "audio/wav": ".wav",
+        "audio/x-wav": ".wav",
+        "audio/webm": ".webm",
+        "audio/mp4": ".mp4",
+        "video/mp4": ".mp4",
+        "audio/x-m4a": ".m4a",
+    }
+    return mapping.get(ct, "")
+
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = openai.OpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY and openai else None
@@ -19,7 +39,12 @@ async def _download_audio(url: str) -> str:
     async with httpx.AsyncClient() as hc:
         resp = await hc.get(url)
         resp.raise_for_status()
-        suffix = Path(url).suffix or ".tmp"
+        cleaned_url = url.split("?", 1)[0]
+        suffix = Path(cleaned_url).suffix
+        if not suffix:
+            suffix = _guess_extension(resp.headers.get("content-type", ""))
+        if not suffix:
+            suffix = ".tmp"
         fd, path = tempfile.mkstemp(suffix=suffix)
         os.close(fd)
         with open(path, "wb") as f:

--- a/tests/test_audio_transcriber.py
+++ b/tests/test_audio_transcriber.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from plugins.audio_transcriber import _download_audio
+
+
+class DummyClient:
+    def __init__(self, resp: httpx.Response):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url):
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_download_audio_uses_content_type(tmp_path, monkeypatch):
+    content = b"abc123"
+    req = httpx.Request("GET", "https://api.elevenlabs.io/speech")
+    resp = httpx.Response(
+        200, request=req, content=content, headers={"content-type": "audio/mpeg"}
+    )
+    dummy = DummyClient(resp)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: dummy)
+
+    path = await _download_audio("https://api.elevenlabs.io/speech")
+    assert path.endswith(".mp3")
+    with open(path, "rb") as f:
+        assert f.read() == content
+    os.remove(path)


### PR DESCRIPTION
## Summary
- fix audio downloader to detect filetype based on response content-type header
- add regression test for ElevenLabs audio URL

## Testing
- `ruff check plugins/audio_transcriber.py tests/test_audio_transcriber.py`
- `black --check plugins/audio_transcriber.py tests/test_audio_transcriber.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870bce30d38832d9e40344ab8806b90